### PR TITLE
Removed Suggestions While Pausing Video

### DIFF
--- a/website/templates/topic-page.html
+++ b/website/templates/topic-page.html
@@ -54,12 +54,12 @@
                   transform: scale(1.2);
                }
                </style>
-               <a href='https://www.youtube.com/embed/{{ video.vid }}?autoplay=1'>
+               <a href='https://www.youtube.com/embed/{{ video.vid }}?rel=0'>
                   <img src='https://img.youtube.com/vi/{{ video.vid }}/hqdefault.jpg'>
                   <svg xmlns='http://www.w3.org/2000/svg' width='64' height='64' viewBox='0 0 24 24' fill='none' stroke='#ffffff' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' class='feather feather-play-circle'><circle cx='12' cy='12' r='10'></circle><polygon points='10 8 16 12 10 16 10 8'></polygon></svg>
                </a>
                "
-               width="560" height="315" src="https://www.youtube.com/embed/{{ video.vid }}"
+               width="560" height="315" src="https://www.youtube.com/embed/{{ video.vid }}?rel=0"
                title="YouTube video player" frameborder="0"
                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                allowfullscreen>


### PR DESCRIPTION
When We Pause Any Video Youtube Shows Some Video Suggestions So We Can Disable Those Using `?rel=0` at End Of Embed Links.